### PR TITLE
Enable CF Bindings to stick with Hono Route

### DIFF
--- a/src/routes/api/[...all]/+server.ts
+++ b/src/routes/api/[...all]/+server.ts
@@ -1,9 +1,15 @@
 import { hono } from '@server';
 import type { RequestHandler } from '@sveltejs/kit';
 
-export const GET: RequestHandler = ({ request }) => hono.fetch(request);
-export const PUT: RequestHandler = ({ request }) => hono.fetch(request);
-export const DELETE: RequestHandler = ({ request }) => hono.fetch(request);
-export const POST: RequestHandler = ({ request }) => hono.fetch(request);
-export const PATCH: RequestHandler = ({ request }) => hono.fetch(request);
-export const fallback: RequestHandler = ({ request }) => hono.fetch(request);
+export const GET: RequestHandler = ({ request, platform }) =>
+	hono.request(request, {}, platform?.env || {});
+export const PUT: RequestHandler = ({ request, platform }) =>
+	hono.request(request, {}, platform?.env || {});
+export const DELETE: RequestHandler = ({ request, platform }) =>
+	hono.fetch(request, platform?.env || {});
+export const POST: RequestHandler = ({ request, platform }) =>
+	hono.fetch(request, platform?.env || {});
+export const PATCH: RequestHandler = ({ request, platform }) =>
+	hono.fetch(request, platform?.env || {});
+export const fallback: RequestHandler = ({ request, platform }) =>
+	hono.fetch(request, platform?.env || {});


### PR DESCRIPTION
Pass in the platform env object if user is using cloudflare, the bindings will still be passed on the hono route